### PR TITLE
Fix: 修复 Sec-WebSocket-Protocol 格式不正确时的报错

### DIFF
--- a/nonebot/adapters/onebot/v12/adapter.py
+++ b/nonebot/adapters/onebot/v12/adapter.py
@@ -269,16 +269,6 @@ class Adapter(BaseAdapter):
         return Response(204)
 
     async def _handle_ws(self, websocket: WebSocket) -> None:
-        onebot_version, impl = websocket.request.headers.get(
-            "Sec-WebSocket-Protocol", ""
-        ).split(".", 1)
-
-        # check impl
-        if not impl:
-            log("WARNING", "Missing Sec-WebSocket-Protocol Header")
-            await websocket.close(1008, "Missing Sec-WebSocket-Protocol Header")
-            return
-
         # check access_token
         response = self._check_access_token(websocket.request)
         if response is not None:
@@ -289,8 +279,28 @@ class Adapter(BaseAdapter):
         await websocket.accept()
 
         bots: Dict[str, Bot] = {}
-
+        impl = None
         try:
+            # 等待 connect 事件
+            log(
+                "DEBUG",
+                "Waiting for connect meta event",
+            )
+            while impl is None:
+                data = await websocket.receive()
+                raw_data = (
+                    json.loads(data) if isinstance(data, str) else msgpack.unpackb(data)
+                )
+                event = self.json_to_event(raw_data, impl)
+                if not event:
+                    continue
+                if isinstance(event, ConnectMetaEvent):
+                    impl = event.version.impl
+                    log(
+                        "DEBUG",
+                        f"Connect meta event received, impl is {impl}",
+                    )
+
             while True:
                 data = await websocket.receive()
                 raw_data = (
@@ -377,7 +387,7 @@ class Adapter(BaseAdapter):
             ] = f"Bearer {self.onebot_config.onebot_access_token}"
         req = Request("GET", url, headers=headers, timeout=30.0)
         bots: Dict[str, Bot] = {}
-        impl = ""
+        impl = None
         while True:
             try:
                 async with self.websocket(req) as ws:
@@ -391,7 +401,7 @@ class Adapter(BaseAdapter):
                             "DEBUG",
                             "Waiting for connect meta event",
                         )
-                        while not impl:
+                        while impl is None:
                             data = await ws.receive()
                             raw_data = (
                                 json.loads(data)
@@ -523,14 +533,12 @@ class Adapter(BaseAdapter):
 
     @classmethod
     def get_event_model(
-        cls, data: Dict[str, Any], impl: str
+        cls, data: Dict[str, Any], impl: Optional[str] = None
     ) -> Generator[Type[Event], None, None]:
         """根据事件获取对应 `Event Model` 及 `FallBack Event Model` 列表。"""
-        platform = ""
         # 元事件没有 self 字段
-        if "self" in data:
-            platform = data["self"]["platform"]
-        key = f"/{impl}/{platform}"
+        platform = data.get("self", {}).get("platform")
+        key = f"/{impl}/{platform}" if impl and platform else ""
         if key in cls.event_models:
             yield from cls.event_models[key].get_model(data)
         yield from cls.event_models[""].get_model(data)
@@ -555,7 +563,9 @@ class Adapter(BaseAdapter):
         return Exc
 
     @classmethod
-    def json_to_event(cls, json_data: Any, impl: str) -> Optional[Event]:
+    def json_to_event(
+        cls, json_data: Any, impl: Optional[str] = None
+    ) -> Optional[Event]:
         if not isinstance(json_data, dict):
             return None
 

--- a/nonebot/adapters/onebot/v12/adapter.py
+++ b/nonebot/adapters/onebot/v12/adapter.py
@@ -390,7 +390,6 @@ class Adapter(BaseAdapter):
             ] = f"Bearer {self.onebot_config.onebot_access_token}"
         req = Request("GET", url, headers=headers, timeout=30.0)
         bots: Dict[str, Bot] = {}
-        impl = None
         while True:
             try:
                 async with self.websocket(req) as ws:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ nb-autodoc = { git = "https://github.com/nonebot/nb-autodoc.git" }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-addopts = "--cov nonebot.adapters.onebot --cov-report term-missing"
+# addopts = "--cov nonebot.adapters.onebot --cov-report term-missing"
 
 [tool.black]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ nb-autodoc = { git = "https://github.com/nonebot/nb-autodoc.git" }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-# addopts = "--cov nonebot.adapters.onebot --cov-report term-missing"
+addopts = "--cov nonebot.adapters.onebot --cov-report term-missing"
 
 [tool.black]
 line-length = 88

--- a/tests/v12/events.json
+++ b/tests/v12/events.json
@@ -55,5 +55,18 @@
         }
       ]
     }
-  }
+  },
+  {
+    "_model": "ConnectMetaEvent",
+    "id": "b6e65187-5ac0-489c-b431-53078e9d2bbb",
+    "time": 1632847927.599013,
+    "type": "meta",
+    "detail_type": "connect",
+    "sub_type": "",
+    "version": {
+        "impl": "go-onebot-qq",
+        "version": "1.2.0",
+        "onebot_version": "12"
+    }
+}
 ]

--- a/tests/v12/test_v12_connection.py
+++ b/tests/v12/test_v12_connection.py
@@ -52,6 +52,8 @@ async def test_ws(app: App, init_adapter, endpoints: str):
             "Sec-WebSocket-Protocol": "12.test",
         }
         async with client.websocket_connect(endpoints, headers=headers) as ws:
+            await ws.send_json(test_events[2])
+
             await ws.send_json(test_events[0])
             await asyncio.sleep(0)
             bots = nonebot.get_bots()
@@ -159,7 +161,7 @@ async def test_ws_auth_missing(app: App, init_adapter):
         }
         with pytest.raises(AssertionError):
             async with client.websocket_connect(endpoints, headers=headers) as ws:
-                await ws.send_json(test_events[0])
+                await ws.send_json(test_events[2])
                 await asyncio.sleep(0)
 
 
@@ -183,6 +185,8 @@ async def test_ws_auth_header(app: App, init_adapter):
             "Authorization": "Bearer test",
         }
         async with client.websocket_connect(endpoints, headers=headers) as ws:
+            await ws.send_json(test_events[2])
+
             await ws.send_json(test_events[0])
             await asyncio.sleep(0)
             bots = nonebot.get_bots()
@@ -209,6 +213,8 @@ async def test_ws_auth_query(app: App, init_adapter):
             "Sec-WebSocket-Protocol": "12.test",
         }
         async with client.websocket_connect(endpoints, headers=headers) as ws:
+            await ws.send_json(test_events[2])
+
             await ws.send_json(test_events[0])
             await asyncio.sleep(0)
             bots = nonebot.get_bots()

--- a/tests/v12/test_v12_connection.py
+++ b/tests/v12/test_v12_connection.py
@@ -84,7 +84,7 @@ async def test_ws_missing_connect_meta_event(app: App, init_adapter):
             assert e.value.args[0] == {
                 "type": "websocket.close",
                 "code": 1008,
-                "reason": "",
+                "reason": "Missing connect meta event",
             }
 
 


### PR DESCRIPTION
之前将 Sec-WebSocket-Protocol 的值 split 之后赋值给 onebot_version 与 impl，如果其中不包含 `.`，会报 `ValueError: not enough values to unpack`。

现在直接将正向和方向 ws 统一了，都通过 ConnectMetaEvent 获取 impl。

同时发现之前 get_event_model 的 key 写法与 add_custom_model 的 key 不统一，现在统一了。