### PR TITLE
Feature: 优化消息和消息段的`repr()`显示效果

### DIFF
--- a/nonebot/adapters/onebot/utils.py
+++ b/nonebot/adapters/onebot/utils.py
@@ -18,3 +18,27 @@ def get_auth_bearer(access_token: Optional[str] = None) -> Optional[str]:
 def b2s(b: Optional[bool]) -> Optional[str]:
     """转换布尔值为字符串。"""
     return b if b is None else str(b).lower()
+
+
+def truncate(
+    s: str, length: int = 70, kill_words: bool = True, end: str = "..."
+) -> str:
+    """将给定字符串截断到指定长度。
+
+    参数:
+        s: 需要截取的字符串
+        length: 截取长度
+        kill_words: 是否不保留完整单词
+        end: 截取字符串的结尾字符
+
+    返回:
+        截取后的字符串
+    """
+    if len(s) <= length:
+        return s
+
+    if kill_words:
+        return s[: length - len(end)] + end
+
+    result = s[: length - len(end)].rsplit(maxsplit=1)[0]
+    return result + end

--- a/nonebot/adapters/onebot/v11/event.py
+++ b/nonebot/adapters/onebot/v11/event.py
@@ -191,11 +191,7 @@ class PrivateMessageEvent(MessageEvent):
                 )
                 texts.clear()
         msg_string.append(escape_tag("".join(texts)))
-        return (
-            f'Message {self.message_id} from {self.user_id} "'
-            + "".join(msg_string)
-            + '"'
-        )
+        return f"Message {self.message_id} from {self.user_id} {''.join(msg_string)!r}"
 
 
 class GroupMessageEvent(MessageEvent):
@@ -218,11 +214,7 @@ class GroupMessageEvent(MessageEvent):
                 )
                 texts.clear()
         msg_string.append(escape_tag("".join(texts)))
-        return (
-            f'Message {self.message_id} from {self.user_id}@[群:{self.group_id}] "'
-            + "".join(msg_string)
-            + '"'
-        )
+        return f"Message {self.message_id} from {self.user_id}@[群:{self.group_id}] {''.join(msg_string)!r}"
 
     @overrides(MessageEvent)
     def get_session_id(self) -> str:

--- a/nonebot/adapters/onebot/v11/event.py
+++ b/nonebot/adapters/onebot/v11/event.py
@@ -6,6 +6,7 @@ FrontMatter:
 """
 
 from copy import deepcopy
+from functools import reduce
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
 
 from nonebot.typing import overrides
@@ -183,10 +184,10 @@ class PrivateMessageEvent(MessageEvent):
         msg_string: List[str] = []
         for seg in self.original_message:
             if seg.is_text():
-                texts.append(str(seg))
+                texts.append(repr(seg))
             else:
                 msg_string.extend(
-                    (escape_tag("".join(texts)), f"<le>{escape_tag(str(seg))}</le>")
+                    (escape_tag("".join(texts)), f"<le>{escape_tag(repr(seg))}</le>")
                 )
                 texts.clear()
         msg_string.append(escape_tag("".join(texts)))
@@ -210,10 +211,10 @@ class GroupMessageEvent(MessageEvent):
         msg_string: List[str] = []
         for seg in self.original_message:
             if seg.is_text():
-                texts.append(str(seg))
+                texts.append(repr(seg))
             else:
                 msg_string.extend(
-                    (escape_tag("".join(texts)), f"<le>{escape_tag(str(seg))}</le>")
+                    (escape_tag("".join(texts)), f"<le>{escape_tag(repr(seg))}</le>")
                 )
                 texts.clear()
         msg_string.append(escape_tag("".join(texts)))

--- a/nonebot/adapters/onebot/v11/message.py
+++ b/nonebot/adapters/onebot/v11/message.py
@@ -13,11 +13,11 @@ from typing import Type, Tuple, Union, Iterable, Optional
 
 from nonebot.typing import overrides
 
-from nonebot.adapters.onebot.utils import b2s
 from nonebot.adapters import Message as BaseMessage
+from nonebot.adapters.onebot.utils import b2s, truncate
 from nonebot.adapters import MessageSegment as BaseMessageSegment
 
-from .utils import log, escape, truncate, unescape
+from .utils import log, escape, unescape
 
 
 class MessageSegment(BaseMessageSegment["Message"]):
@@ -30,31 +30,23 @@ class MessageSegment(BaseMessageSegment["Message"]):
 
     @overrides(BaseMessageSegment)
     def __str__(self) -> str:
-        type_ = self.type
-        data = self.data.copy()
-
         # process special types
         if self.is_text():
-            return escape(data.get("text", ""), escape_comma=False)
+            return escape(self.data.get("text", ""), escape_comma=False)
 
         params = ",".join(
-            [f"{k}={escape(str(v))}" for k, v in data.items() if v is not None]
+            [f"{k}={escape(str(v))}" for k, v in self.data.items() if v is not None]
         )
-        return f"[CQ:{type_}{',' if params else ''}{params}]"
+        return f"[CQ:{self.type}{',' if params else ''}{params}]"
 
-    @overrides(BaseMessageSegment)
     def __repr__(self) -> str:
-        type_ = self.type
-        data = self.data.copy()
-
         if self.is_text():
-            text = escape(data.get("text", ""), escape_comma=False)
-            return "".join(repr(text)[1:-1])  # remove single quotes around text
+            return escape(self.data.get("text", ""), escape_comma=False)
 
         params = ", ".join(
-            [f"{k}={truncate(v)}" for k, v in data.items() if v is not None]
+            [f"{k}={truncate(str(v))}" for k, v in self.data.items() if v is not None]
         )
-        return f"[{type_}{':' if params else ''}{params}]"
+        return f"[{self.type}{':' if params else ''}{params}]"
 
     @overrides(BaseMessageSegment)
     def __add__(

--- a/nonebot/adapters/onebot/v11/message.py
+++ b/nonebot/adapters/onebot/v11/message.py
@@ -49,8 +49,7 @@ class MessageSegment(BaseMessageSegment["Message"]):
 
         if self.is_text():
             text = escape(data.get("text", ""), escape_comma=False)
-            _, *text_repr, _ = repr(text)  # remove single quotes around text
-            return "".join(text_repr)
+            return "".join(repr(text)[1:-1])  # remove single quotes around text
 
         params = ", ".join(
             [f"{k}={truncate(v)}" for k, v in data.items() if v is not None]

--- a/nonebot/adapters/onebot/v11/message.py
+++ b/nonebot/adapters/onebot/v11/message.py
@@ -9,7 +9,7 @@ import re
 from io import BytesIO
 from pathlib import Path
 from base64 import b64encode
-from typing import Any, Type, Tuple, Union, Iterable, Optional
+from typing import Type, Tuple, Union, Iterable, Optional
 
 from nonebot.typing import overrides
 
@@ -17,7 +17,7 @@ from nonebot.adapters.onebot.utils import b2s
 from nonebot.adapters import Message as BaseMessage
 from nonebot.adapters import MessageSegment as BaseMessageSegment
 
-from .utils import log, escape, unescape
+from .utils import log, escape, truncate, unescape
 
 
 class MessageSegment(BaseMessageSegment["Message"]):
@@ -34,7 +34,7 @@ class MessageSegment(BaseMessageSegment["Message"]):
         data = self.data.copy()
 
         # process special types
-        if type_ == "text":
+        if self.is_text():
             return escape(data.get("text", ""), escape_comma=False)
 
         params = ",".join(
@@ -47,19 +47,10 @@ class MessageSegment(BaseMessageSegment["Message"]):
         type_ = self.type
         data = self.data.copy()
 
-        if type_ == "text":
+        if self.is_text():
             text = escape(data.get("text", ""), escape_comma=False)
-            _, *text_repr, _ = repr(text)  # for better repr handling
-            return ''.join(text_repr)
-
-        def truncate(data: Any, length: int = 70):
-            data_repr = repr(data)
-
-            if len(data_repr) > length:
-                prefix = data_repr[: length // 2]
-                suffix = data_repr[-length // 2 :]
-                data_repr = f"{prefix}…{suffix}"
-            return data_repr
+            _, *text_repr, _ = repr(text)  # remove single quotes around text
+            return "".join(text_repr)
 
         params = ", ".join(
             [f"{k}={truncate(v)}" for k, v in data.items() if v is not None]
@@ -302,7 +293,7 @@ class Message(BaseMessage[MessageSegment]):
         )
 
     def __repr__(self) -> str:
-        return ''.join([repr(seg) for seg in self])
+        return "".join(repr(seg) for seg in self)
 
     @overrides(BaseMessage)
     def __radd__(

--- a/nonebot/adapters/onebot/v11/utils.py
+++ b/nonebot/adapters/onebot/v11/utils.py
@@ -57,3 +57,30 @@ def handle_api_result(result: Optional[Dict[str, Any]]) -> Any:
         if result.get("status") == "failed":
             raise ActionFailed(**result)
         return result.get("data")
+
+
+def truncate(
+    s: str,
+    length: int = 70,
+    kill_words: bool = True,
+    end: str = "...",
+) -> str:
+    """将给定字符串截断到指定长度。
+
+    参数:
+        s: 需要截取的字符串
+        length: 截取长度
+        kill_words: 是否不保留完整单词
+        end: 截取字符串的结尾字符
+
+    返回:
+        截取后的字符串
+    """
+    if len(s) <= length:
+        return s
+
+    if kill_words:
+        return s[: length - len(end)] + end
+
+    result = s[: length - len(end)].rsplit(" ", 1)[0]
+    return result + end

--- a/nonebot/adapters/onebot/v11/utils.py
+++ b/nonebot/adapters/onebot/v11/utils.py
@@ -57,30 +57,3 @@ def handle_api_result(result: Optional[Dict[str, Any]]) -> Any:
         if result.get("status") == "failed":
             raise ActionFailed(**result)
         return result.get("data")
-
-
-def truncate(
-    s: str,
-    length: int = 70,
-    kill_words: bool = True,
-    end: str = "...",
-) -> str:
-    """将给定字符串截断到指定长度。
-
-    参数:
-        s: 需要截取的字符串
-        length: 截取长度
-        kill_words: 是否不保留完整单词
-        end: 截取字符串的结尾字符
-
-    返回:
-        截取后的字符串
-    """
-    if len(s) <= length:
-        return s
-
-    if kill_words:
-        return s[: length - len(end)] + end
-
-    result = s[: length - len(end)].rsplit(" ", 1)[0]
-    return result + end

--- a/nonebot/adapters/onebot/v12/event.py
+++ b/nonebot/adapters/onebot/v12/event.py
@@ -150,18 +150,14 @@ class PrivateMessageEvent(MessageEvent):
         msg_string: List[str] = []
         for seg in self.original_message:
             if seg.is_text():
-                texts.append(str(seg))
+                texts.append(repr(seg))
             else:
                 msg_string.extend(
-                    (escape_tag("".join(texts)), f"<le>{escape_tag(str(seg))}</le>")
+                    (escape_tag("".join(texts)), f"<le>{escape_tag(repr(seg))}</le>")
                 )
                 texts.clear()
         msg_string.append(escape_tag("".join(texts)))
-        return (
-            f'Message {self.message_id} from {self.user_id} "'
-            + "".join(msg_string)
-            + '"'
-        )
+        return f"Message {self.message_id} from {self.user_id} {''.join(msg_string)!r}"
 
 
 class GroupMessageEvent(MessageEvent):
@@ -183,11 +179,7 @@ class GroupMessageEvent(MessageEvent):
                 )
                 texts.clear()
         msg_string.append(escape_tag("".join(texts)))
-        return (
-            f'Message {self.message_id} from {self.user_id}@[群:{self.group_id}] "'
-            + "".join(msg_string)
-            + '"'
-        )
+        return f"Message {self.message_id} from {self.user_id}@[群:{self.group_id}] {''.join(msg_string)!r}"
 
     @overrides(MessageEvent)
     def get_session_id(self) -> str:
@@ -203,18 +195,20 @@ class ChannelMessageEvent(MessageEvent):
 
     @overrides(Event)
     def get_event_description(self) -> str:
+        texts: List[str] = []
+        msg_string: List[str] = []
+        for seg in self.original_message:
+            if seg.is_text():
+                texts.append(str(seg))
+            else:
+                msg_string.extend(
+                    (escape_tag("".join(texts)), f"<le>{escape_tag(str(seg))}</le>")
+                )
+                texts.clear()
+        msg_string.append(escape_tag("".join(texts)))
         return (
             f"Message {self.message_id} from {self.user_id}@"
-            f'[群组:{self.guild_id}, 频道:{self.channel_id}] "'
-            + "".join(
-                map(
-                    lambda x: escape_tag(str(x))
-                    if x.is_text()
-                    else f"<le>{escape_tag(str(x))}</le>",
-                    self.message,
-                )
-            )
-            + '"'
+            f"[群组:{self.guild_id}, 频道:{self.channel_id}] {''.join(msg_string)!r}"
         )
 
     @overrides(MessageEvent)

--- a/nonebot/adapters/onebot/v12/message.py
+++ b/nonebot/adapters/onebot/v12/message.py
@@ -9,6 +9,7 @@ from typing import Any, Type, Iterable
 
 from nonebot.typing import overrides
 
+from nonebot.adapters.onebot.utils import truncate
 from nonebot.adapters import Message as BaseMessage
 from nonebot.adapters import MessageSegment as BaseMessageSegment
 
@@ -23,12 +24,20 @@ class MessageSegment(BaseMessageSegment["Message"]):
 
     @overrides(BaseMessageSegment)
     def __str__(self) -> str:
-        if self.type == "text":
+        if self.is_text():
             return self.data.get("text", "")
-        params = ",".join(
-            [f"{k}={str(v)}" for k, v in self.data.items() if v is not None]
+
+        params = ", ".join([f"{k}={v}" for k, v in self.data.items() if v is not None])
+        return f"[{self.type}{':' if params else ''}{params}]"
+
+    def __repr__(self) -> str:
+        if self.is_text():
+            return self.data.get("text", "")
+
+        params = ", ".join(
+            [f"{k}={truncate(str(v))}" for k, v in self.data.items() if v is not None]
         )
-        return f"[{self.type}:{params}]"
+        return f"[{self.type}{':' if params else ''}{params}]"
 
     @overrides(BaseMessageSegment)
     def is_text(self) -> bool:
@@ -95,6 +104,9 @@ class Message(BaseMessage[MessageSegment]):
     @overrides(BaseMessage)
     def get_segment_class(cls) -> Type[MessageSegment]:
         return MessageSegment
+
+    def __repr__(self) -> str:
+        return "".join(repr(seg) for seg in self)
 
     @staticmethod
     @overrides(BaseMessage)

--- a/tests/v11/events.json
+++ b/tests/v11/events.json
@@ -17,5 +17,26 @@
       "sex": "unknown",
       "age": 0
     }
+  },
+  {
+    "_model": "GroupMessageEvent",
+    "self_id": 0,
+    "time": 0,
+    "post_type": "message",
+    "message_type": "group",
+    "sub_type": "normal",
+    "message_id": 1,
+    "user_id": 1,
+    "group_id": 1,
+    "message": "[CQ:at,qq=all] Test text",
+    "raw_message": "[CQ:at,qq=all] Test text",
+    "font": 0,
+    "sender": {
+      "user_id": 1,
+      "nickname": "Test",
+      "sex": "unknown",
+      "age": 0
+    },
+    "anonymous": null
   }
 ]

--- a/tests/v11/test_v11_message.py
+++ b/tests/v11/test_v11_message.py
@@ -5,6 +5,9 @@ import pytest
 async def test_message_escape(init_adapter):
     from nonebot.adapters.onebot.v11 import Message, MessageSegment
 
+    a = Message([MessageSegment.text("test"), MessageSegment.at(123)])
+    assert Message(str(a)) == a
+
     assert Message() + "[CQ:test]" == Message(MessageSegment.text("[CQ:test]"))
     assert "[CQ:test]" + Message() == Message(MessageSegment.text("[CQ:test]"))
 


### PR DESCRIPTION
包含以下改进:

- 在`MessageSegment`的param过长时进行truncate, 防止日志刷屏
- 对`text`类型的`MessageSegment`使用`repr()`展示, 防止换行过多刷屏和扰乱日志输出
- 不再展示任何类似CQ码的内容 ~~, 防止天才用户看到就想用正则~~