### PR TITLE
Fix: 修复遇到不同协议相同 ID 的机器人连接时没有正常报错断开连接的问题

### DIFF
--- a/nonebot/adapters/onebot/v12/adapter.py
+++ b/nonebot/adapters/onebot/v12/adapter.py
@@ -321,9 +321,9 @@ class Adapter(BaseAdapter):
                         bot = bots.get(self_id)
                         if not bot:
                             bot = Bot(self, self_id, event.self.platform)
+                            self.bot_connect(bot)
                             bots[self_id] = bot
                             self.connections[self_id] = websocket
-                            self.bot_connect(bot)
                             log(
                                 "INFO",
                                 f"<y>Bot {escape_tag(event.self.user_id)}</y> connected",
@@ -440,9 +440,9 @@ class Adapter(BaseAdapter):
                                 bot = bots.get(self_id)
                                 if not bot:
                                     bot = Bot(self, self_id, event.self.platform)
+                                    self.bot_connect(bot)
                                     bots[self_id] = bot
                                     self.connections[self_id] = ws
-                                    self.bot_connect(bot)
                                     log(
                                         "INFO",
                                         f"<y>Bot {escape_tag(event.self.user_id)}</y> connected",
@@ -501,11 +501,12 @@ class Adapter(BaseAdapter):
             elif self_id not in self.bots:
                 bot = Bot(self, self_id, platform)
 
+                # 先尝试连接，如果失败则不保存连接信息
+                self.bot_connect(bot)
                 # 正向与反向 WebSocket 连接需要额外保存连接信息
                 if bots is not None and websocket is not None:
                     bots[self_id] = bot
                     self.connections[self_id] = websocket
-                self.bot_connect(bot)
 
                 log(
                     "INFO",

--- a/tests/v12/events.json
+++ b/tests/v12/events.json
@@ -64,9 +64,30 @@
     "detail_type": "connect",
     "sub_type": "",
     "version": {
-        "impl": "go-onebot-qq",
-        "version": "1.2.0",
-        "onebot_version": "12"
+      "impl": "go-onebot-qq",
+      "version": "1.2.0",
+      "onebot_version": "12"
     }
-}
+  },
+  {
+    "_model": "StatusUpdateMetaEvent",
+    "id": "b6e65187-5ac0-489c-b431-53078e9d2bbb",
+    "time": 1632847927.599013,
+    "type": "meta",
+    "detail_type": "status_update",
+    "sub_type": "",
+    "status": {
+      "good": true,
+      "bots": [
+        {
+          "self": {
+            "platform": "qq",
+            "user_id": "0"
+          },
+          "online": true,
+          "qq.status": "信号强"
+        }
+      ]
+    }
+  }
 ]

--- a/tests/v12/test_v12_connection.py
+++ b/tests/v12/test_v12_connection.py
@@ -137,8 +137,9 @@ async def test_ws_duplicate_bot(app: App, init_adapter):
             await ws.send_json(test_events[2])
             await ws.send_json(test_events[0])
 
+            # 如果第二次是 TimeoutError，说明 bot 被移除了，这个测试会报错
             with pytest.raises(Exception) as e:
-                await ws.receive_json()
+                await asyncio.wait_for(ws.receive_json(), 5)
             assert e.value.args[0] == {
                 "type": "websocket.close",
                 "code": 1000,

--- a/tests/v12/test_v12_connection.py
+++ b/tests/v12/test_v12_connection.py
@@ -88,6 +88,64 @@ async def test_ws_missing_connect_meta_event(app: App, init_adapter):
             }
 
 
+async def test_ws_duplicate_bot(app: App, init_adapter):
+    """测试连接两个相同 id 但协议不同的 bot"""
+    import nonebot
+
+    # 先连接一个 v11 bot
+    endpoints = "/onebot/v11/"
+
+    with (Path(__file__).parent.parent / "v11" / "events.json").open(
+        "r", encoding="utf8"
+    ) as f:
+        test_events = json.load(f)
+
+    async with app.test_server() as ctx:
+        client = ctx.get_client()
+        event = test_events[0]
+        headers = {"X-Self-ID": "0"}
+        resp = await client.post(endpoints, json=event, headers=headers)
+        assert resp.status_code == 204
+        bots = nonebot.get_bots()
+        assert "0" in bots
+
+    # 再连接一个 v12 bot
+    endpoints = "/onebot/v12/"
+
+    with (Path(__file__).parent / "events.json").open("r", encoding="utf8") as f:
+        test_events = json.load(f)
+
+    async with app.test_server() as ctx:
+        client = ctx.get_client()
+        headers = {
+            "Sec-WebSocket-Protocol": "12.test",
+        }
+        async with client.websocket_connect(endpoints, headers=headers) as ws:
+            await ws.send_json(test_events[2])
+            await ws.send_json(test_events[0])
+
+            with pytest.raises(Exception) as e:
+                await ws.receive_json()
+            assert e.value.args[0] == {
+                "type": "websocket.close",
+                "code": 1000,
+                "reason": "",
+            }
+
+        # 再次尝试依旧会报错，而不会因为 bot 被错误移除而正常连接
+        async with client.websocket_connect(endpoints, headers=headers) as ws:
+            await ws.send_json(test_events[2])
+            await ws.send_json(test_events[0])
+
+            with pytest.raises(Exception) as e:
+                await ws.receive_json()
+            assert e.value.args[0] == {
+                "type": "websocket.close",
+                "code": 1000,
+                "reason": "",
+            }
+
+
 @pytest.mark.parametrize(
     "nonebug_init",
     [pytest.param({"onebot_v12_access_token": "test"}, id="access_token")],


### PR DESCRIPTION
因为调用 bot_connect 前已将 bot 存放至 bots 中，当遇到 self_id 重复的情况时，异常处理会将已有的 bot 移除。导致第二次重连时能正常连接成功，同时已有的连接不会断开。这时候 nb 能够同时处理两个 self_id 相同的机器人收到的事件。


相关 issue：<https://github.com/he0119/CoolQBot/issues/264>