### PR TITLE
为 ob v11 添加”合并转发“的功能

### DIFF
--- a/nonebot/adapters/onebot/v11/bot.py
+++ b/nonebot/adapters/onebot/v11/bot.py
@@ -171,6 +171,23 @@ async def send(
     full_message += message
     params.setdefault("message", full_message)
 
+    # only when all message segment types are 'node' triggers send_*_forward_msg
+    is_forward_msg = True
+    for message_segment in full_message:
+        if message_segment.type != "node":
+            is_forward_msg = False
+            break
+
+    if is_forward_msg:
+        if params.get("message_type") == "group":
+            return await bot.send_group_forward_msg(
+                group_id=params.get("group_id"), messages=full_message
+            )
+        elif params.get("message_type") == "private":
+            return await bot.send_private_forward_msg(
+                user_id=params.get("user_id"), messages=full_message
+            )
+
     return await bot.send_msg(**params)
 
 

--- a/nonebot/adapters/onebot/v11/bot.pyi
+++ b/nonebot/adapters/onebot/v11/bot.pyi
@@ -86,6 +86,26 @@ class Bot(BaseBot):
             auto_escape: 消息内容是否作为纯文本发送（即不解析 CQ 码），只在 `message` 字段是字符串时有效
         """
         ...
+    async def send_group_forward_msg(
+        self, *, group_id: int, messages: Message
+    ) -> Dict[str, Any]:
+        """发送合并转发 ( 群 )
+
+        参数:
+            group_id: 群号
+            messages: MessageSegment 类型全部为 Node 的 Message
+        """
+        ...
+    async def send_private_forward_msg(
+        self, *, group_id: int, messages: Message
+    ) -> Dict[str, Any]:
+        """发送合并转发 ( 好友 )
+
+        参数:
+            user_id: 好友QQ号
+            messages: MessageSegment 类型全部为 Node 的 Message
+        """
+        ...
     async def delete_msg(
         self,
         *,


### PR DESCRIPTION
* 在 bot.pyi 中添加 send_group_forward_msg send_private_forward_msg 的函数签名
* 在默认 send 函数中，如果检测到所有 MessageSegment 都是 node 类型，就自动使用 send_*_forward_msg 来发送消息