### PR TITLE
Fix: `get_forward_msg` 接口返回类型注释错误

### DIFF
--- a/nonebot/adapters/onebot/v11/bot.pyi
+++ b/nonebot/adapters/onebot/v11/bot.pyi
@@ -110,7 +110,7 @@ class Bot(BaseBot):
         self,
         *,
         id: str,
-    ) -> None:
+    ) -> dict[str, Any]:
         """获取合并转发消息。
 
         参数:


### PR DESCRIPTION
根据 [OneBot V11 标准][3]，`get_forward_msg` 的响应数据应该是 `dict[str, Any]`，而不是 `None`

<details open>
<summary>OneBot V11 标准原文</summary>

## `get_forward_msg` 获取合并转发消息

### 参数

| 字段名         | 数据类型   | 说明   |
| ------------ | ------ | ------ |
| `id` | string | 合并转发 ID |

### 响应数据

| 字段名 | 类型 | 说明 |
| --- | --- | --- |
| `message` | message | 消息内容，使用 [消息的数组格式][1] 表示，数组中的消息段全部为 [`node` 消息段][2] |
</details>

[1]: https://github.com/botuniverse/onebot-11/blob/master/message/array.md
[2]: https://github.com/botuniverse/onebot-11/blob/master/message/segment.md#%E5%90%88%E5%B9%B6%E8%BD%AC%E5%8F%91%E8%87%AA%E5%AE%9A%E4%B9%89%E8%8A%82%E7%82%B9
[3]: https://github.com/botuniverse/onebot-11/blob/master/api/public.md#get_forward_msg-%E8%8E%B7%E5%8F%96%E5%90%88%E5%B9%B6%E8%BD%AC%E5%8F%91%E6%B6%88%E6%81%AF