### PR TITLE
Fix: 加群/添加好友请求的 comment 可能为 None

### DIFF
--- a/nonebot/adapters/onebot/v11/event.py
+++ b/nonebot/adapters/onebot/v11/event.py
@@ -485,7 +485,7 @@ class FriendRequestEvent(RequestEvent):
 
     request_type: Literal["friend"]
     user_id: int
-    comment: str
+    comment: Optional[str]
     flag: str
 
     @override
@@ -512,7 +512,7 @@ class GroupRequestEvent(RequestEvent):
     sub_type: str
     group_id: int
     user_id: int
-    comment: str
+    comment: Optional[str]
     flag: str
 
     @override

--- a/nonebot/adapters/onebot/v11/event.py
+++ b/nonebot/adapters/onebot/v11/event.py
@@ -485,8 +485,8 @@ class FriendRequestEvent(RequestEvent):
 
     request_type: Literal["friend"]
     user_id: int
-    comment: Optional[str]
     flag: str
+    comment: Optional[str] = None
 
     @override
     def get_user_id(self) -> str:
@@ -512,8 +512,8 @@ class GroupRequestEvent(RequestEvent):
     sub_type: str
     group_id: int
     user_id: int
-    comment: Optional[str]
     flag: str
+    comment: Optional[str] = None
 
     @override
     def get_user_id(self) -> str:


### PR DESCRIPTION
lagrange-onebot
```
[request.group.invite]: {'time': 1709617740, 'self_id': ****, 'post_type': 'request', 'request_type': 'group', 'sub_type': 'invite', 'group_id': ****, 'user_id': ****, 'comment': None, 'flag': '****', 'invitor_id': 0}
```